### PR TITLE
Save quagga config to file to make the router survive after a reboot

### DIFF
--- a/vagrant/demos/clos-ospf/clospf.yml
+++ b/vagrant/demos/clos-ospf/clospf.yml
@@ -34,4 +34,7 @@
     with_items:
       - sudo cl-ospf interface set lo passive
       - sudo cl-ospf interface set lo area 0.0.0.0
-    
+
+  - name: Save configuration to file
+    command: sudo cl-rctl write-config
+


### PR DESCRIPTION
If you reboot the virtual machines created with vagrant the quagga configuration is lost because is never written to file. This patch fixes the problem.

I guess most of users will try to reboot machines to see what happens to ospf topology when you reboot a device.