### PR TITLE
Feature fix ansible2 deprecated warns

### DIFF
--- a/vagrant/demos/clos-bgp/clbgp.yml
+++ b/vagrant/demos/clos-bgp/clbgp.yml
@@ -34,7 +34,7 @@
       - [ 'cl-rctl interface clear %iface% ipv6 nd suppress-ra',
           'cl-rctl interface set %iface% ipv6 nd ra-interval 5'
         ]
-      - ansible_interfaces
+      - '{{ansible_interfaces}}'
     when: item[1] != "lo" and item[1] != "eth0" and ansible_{{ item[1] }}["active"]
 
   - name: Start BGP session on all active interfaces
@@ -48,7 +48,7 @@
           'cl-bgp timers set connect 10 neighbor %iface% ',
           'cl-bgp maximum-paths set 16'
         ]
-      - ansible_interfaces
+      - '{{ansible_interfaces}}'
     when: item[1] != "lo" and item[1] != "eth0" and ansible_{{ item[1] }}["active"]
 
   - name: Announce loopback IP address

--- a/vagrant/demos/clos-bgp/clbgp.yml
+++ b/vagrant/demos/clos-bgp/clbgp.yml
@@ -9,27 +9,29 @@
 
     # The only address we need
   - name: Assign IP address to loopback
-    command: sudo ip addr add {{ loopback_ip }} dev lo
+    command: ip addr add {{ loopback_ip }} dev lo
     when: hostvars[inventory_hostname]['ansible_lo']['ipv4_secondaries'] is not defined
+    become: yes
 
   - name: Enable bgpd and zebra
     replace: dest=/etc/quagga/daemons regexp='(bgpd|zebra)=no' replace='\1=yes' backup=yes
-    sudo: yes
+    become: yes
 
   - name: Write our ASN into bgpd.conf
     shell: sh -c 'echo router bgp {{ asn }} > /etc/quagga/bgpd.conf'
-    sudo: yes
+    become: yes
 
   - name: Restart quagga
     service: name=quagga state=restarted
-    sudo: yes
+    become: yes
 
   - name: Assign router-id
-    command: sudo cl-bgp router-id set {{ loopback_ip }}
+    command: cl-bgp router-id set {{ loopback_ip }}
+    become: yes
 
   - name: Enable IPv6 RA on all active interfaces
     command: "{{ item[0] | replace('%iface%', item[1]) }}"
-    sudo: yes
+    become: yes
     with_nested:
       - [ 'cl-rctl interface clear %iface% ipv6 nd suppress-ra',
           'cl-rctl interface set %iface% ipv6 nd ra-interval 5'
@@ -39,7 +41,7 @@
 
   - name: Start BGP session on all active interfaces
     command: "{{ item[0] | replace('%iface%', item[1]) | replace('%asn%', peer_asn[item[1]]) }}"
-    sudo: yes
+    become: yes
     with_nested:
       - [ 'cl-bgp interface add %iface% ',
           'cl-bgp neighbor add %iface% remote-as %asn%',
@@ -53,9 +55,8 @@
 
   - name: Announce loopback IP address
     command: "cl-bgp network add {{ loopback_ip }}/32"
-    sudo: yes
-    
+    become: yes
+
   - name: Save to quagga config files
     command: "vtysh -c \"write mem\""
-    sudo: yes
-    
+    become: yes


### PR DESCRIPTION
Fix warnings on deprecated syntax with Ansible 2

bare variables
```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your 
playbooks so that the environment value uses the full variable syntax 
('{{ansible_interfaces}}').
This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.

```
- https://docs.ansible.com/ansible/porting_guide_2.0.html#deprecated

sudo
```
 [DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and 
make sure become_method is 'sudo' (default).
This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.

```
- http://docs.ansible.com/ansible/become.html