### PR TITLE
update bgp cl-bgp router-id set syntax

### DIFF
--- a/vagrant/demos/clos-bgp/clbgp.yml
+++ b/vagrant/demos/clos-bgp/clbgp.yml
@@ -26,7 +26,7 @@
     become: yes
 
   - name: Assign router-id
-    command: cl-bgp router-id set {{ loopback_ip }}
+    command: cl-bgp as {{ asn }} router-id set {{ loopback_ip }}
     become: yes
 
   - name: Enable IPv6 RA on all active interfaces


### PR DESCRIPTION
it appears cl-bgp router-id set {{ loopback_ip }} need to be cl-bgp as {{ asn }} router-id set {{ loopback_ip }} on version 3.1.0.