### PR TITLE
Fix netmask for static network assignment

### DIFF
--- a/vagrant/vagrant-cumulus/templates/guests/cumulus/network_static.erb
+++ b/vagrant/vagrant-cumulus/templates/guests/cumulus/network_static.erb
@@ -4,5 +4,6 @@ auto <%= options[:name] %>
 iface <%= options[:name] %>
 <% if options[:ip] %>
       address <%= options[:ip] %>
+      netmask <%= options[:netmask] %>
 <% end %>
 #VAGRANT-END


### PR DESCRIPTION
Added the netmask for static networks in the cumulus plugin.

Understood that this is not needed anymore .. but without it, pandemonium ensues.